### PR TITLE
Depend on matplotlib, not matplotlib-base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
+.vimsession
 
 build_artifacts

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script:
     - "{{ PYTHON }} -m pip install . -vv"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - setuptools >=30.3.0
   run:
     - python >=3.6
-    - matplotlib-base
+    - matplotlib
     - pyyaml
 
 test:


### PR DESCRIPTION
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Details

I'm aware of the [debate](https://github.com/conda-forge/conda-forge.github.io/issues/933) between `matplotlib` vs. `matplotlib-base` as it relates to the `pyqt` dependency, but the latter seems to be causing issues:

1. Most of my users already have the full version of matplotlib `conda install`ed. The `matplotlib-base` dependency seems to result in *two* full installations: a (much older) `matplotlib-base` v2.X, and the full `matplotlib` installation.
2. When I `conda uninstall proplot`, it also uninstalls matplotlib-base, but for some reason my conda distribution still thinks `matplotlib-base` is installed. As a result, when I try to `import matplotlib` afterwards, it imports an *empty namespace*. (Perhaps this is worthy of submitting an issue?)

Also, most of my users probably don't need `pyqt` independently, and since ProPlot tries to automatically enable `%matplotlib qt` for console-IPython I think it makes sense include `pyqt` as an "implied" dependency of ProPlot (dependency of the matplotlib dependency).